### PR TITLE
Use 'paths' instead 'path' argument

### DIFF
--- a/src/Cli/ParallelController.php
+++ b/src/Cli/ParallelController.php
@@ -193,7 +193,7 @@ abstract class ParallelController
      */
     private function createTasks()
     {
-        $path = $this->input->hasArgument('path') ? $this->input->getArgument('path') : null;
+        $path = $this->input->hasArgument('paths') ? $this->input->getArgument('paths') : null;
         if (! is_string($path) && $path !== null) {
             throw new UnexpectedValue('Expected string or null');
         }


### PR DESCRIPTION
If I'm not mistaken behat doesn't know a 'path' argument in any of its versions (2.5, 3.x, 4.x) but always uses 'paths': https://github.com/Behat/Behat/blob/2a3832d9cb853a794af3a576f9e524ae460f3340/src/Behat/Testwork/Tester/Cli/ExerciseController.php#L132

I'm not entirely sure if this change in "expectation" e.g. single vs. possible multi-value has any subsequent implications. If the "locator" is used with the core behat api it should be properly handled there as far as I understand.