### PR TITLE
Fix `paths` argument handling

### DIFF
--- a/src/Cli/ParallelController.php
+++ b/src/Cli/ParallelController.php
@@ -194,8 +194,13 @@ abstract class ParallelController
     private function createTasks()
     {
         $paths = $this->input->hasArgument('paths') ? $this->input->getArgument('paths') : null;
-        if (!is_array($paths) && $paths !== null) {
-            throw new UnexpectedValue('Expected array or null');
+
+        if (is_null($paths) || is_string($paths)) {
+            return $this->taskFactory->createTasks($this->input, $paths);
+        }
+
+        if (!is_array($paths)) {
+            throw new UnexpectedValue('Expected array, string or null');
         }
 
         if (empty($paths)) {

--- a/src/Cli/ParallelController.php
+++ b/src/Cli/ParallelController.php
@@ -193,12 +193,21 @@ abstract class ParallelController
      */
     private function createTasks()
     {
-        $path = $this->input->hasArgument('paths') ? $this->input->getArgument('paths') : null;
-        if (! is_string($path) && $path !== null) {
-            throw new UnexpectedValue('Expected string or null');
+        $paths = $this->input->hasArgument('paths') ? $this->input->getArgument('paths') : null;
+        if (!is_array($paths) && $paths !== null) {
+            throw new UnexpectedValue('Expected array or null');
         }
 
-        return $this->taskFactory->createTasks($this->input, $path);
+        if (empty($paths)) {
+            return $this->taskFactory->createTasks($this->input, null);
+        }
+
+        $tasks = [];
+        foreach ($paths as $path) {
+            $tasks = array_merge($tasks, $this->taskFactory->createTasks($this->input, $path));
+        }
+
+        return $tasks;
     }
 
     /**


### PR DESCRIPTION
The previous fix introduced by @das-peter actually broke the extension, as `paths` argument is array type by default and now extension won't even start (I did check with a fresh symfony+behat+extension project, setup as described in README.md). So here is the actual fix to support `paths` instead of `path`.