### PR TITLE
Support Behat 4 and Symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,14 +13,14 @@
   ],
   "require": {
     "php": ">=7.4",
-    "behat/behat": "^3.9",
-    "symfony/process": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/console": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/serializer": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/dependency-injection": "^4.0 || ^4.1.12 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/event-dispatcher": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/yaml": "^4.0 || ^5.0 || ^6.0 || ^7.0",
-    "symfony/expression-language": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+    "behat/behat": "^3.9 || ^4.0",
+    "symfony/process": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/console": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/serializer": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/dependency-injection": "^4.0 || ^4.1.12 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/event-dispatcher": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/yaml": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+    "symfony/expression-language": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5 || ^9.0",

--- a/src/Cli/ParallelController.php
+++ b/src/Cli/ParallelController.php
@@ -78,7 +78,7 @@ abstract class ParallelController
     /**
      * @return int|null
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): ?int
     {
         $startInParallel = $this->getParallelOption($input) !== false;
         if (! $startInParallel) {

--- a/src/Cli/RerunController.php
+++ b/src/Cli/RerunController.php
@@ -37,7 +37,7 @@ final class RerunController implements Controller
     /**
      * {@inheritDoc}
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): ?int
     {
         $this->eventDispatcher->addListener(
             AfterTaskTested::AFTER,

--- a/src/Cli/SigintController.php
+++ b/src/Cli/SigintController.php
@@ -26,7 +26,7 @@ final class SigintController implements Controller
     /**
      * @inheritDoc
      */
-    public function execute(InputInterface $input, OutputInterface $output)
+    public function execute(InputInterface $input, OutputInterface $output): ?int
     {
         if (! $this->isParallelModeEnabled($input)) {
             return null;

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -18,7 +18,7 @@ class Extension implements ExtensionInterface
     /**
      * @return string
      */
-    public function getConfigKey()
+    public function getConfigKey(): string
     {
         return 'parallel_extension';
     }


### PR DESCRIPTION
Behat 4 declares `Controller::execute(): ?int` and `Extension::getConfigKey(): string`. Four
implementations here lack those return types, which is a fatal error under Behat 4:

```
Declaration of DMarynicz\BehatParallelExtension\Cli\ParallelController::execute(...)
must be compatible with Behat\Testwork\Cli\Controller::execute(...): ?int
```

This adds them to `ParallelController`, `RerunController`, `SigintController` and `Extension`, and
widens the constraints to `behat/behat: ^3.9 || ^4.0` plus `|| ^8.0` on the symfony components.

Adding a return type where the parent declares none is allowed, so Behat 3 keeps working. Constraints
are widened rather than moved — nothing is forced to upgrade.

## Verified on both stacks, PHP 8.5

**Behat 3.32.0**, default resolution — the existing-user path:

| | |
|---|---|
| phpstan | no errors |
| phpunit | 78 tests, 189 assertions |
| behat | 18 scenarios, 99 steps |

`symfony/process`, `serializer` and `expression-language` resolve to v8.1.6 here. The other four stay
on 7.x because Behat 3 caps them.

**Behat 4.0.0-alpha1**, all seven symfony components on v8 — phpstan clean. Since the suite below can't
run on Behat 4 yet, parallel execution was verified in a separate consumer project:

```
serial:        1335ms   (3 scenarios, 3 passed)
--parallel 3:   903ms   (3/3, progress bar, real workers)
```

## Not included: porting this project's own Behat suite

It still runs under Behat 3. Behat 4 removed **both** docblock annotations and YAML configuration, so
porting means converting every context to `#[Given]` attributes and all seven fixture `behat.yml.dist`
files to PHP — and those can't serve Behat 3 at the same time.

That makes it a decision about whether to drop Behat 3, which seemed yours to make rather than
something to slip into this PR. Happy to do that work separately if you'd like it, in either direction.

## CI

Couldn't commit a workflow change (token lacks `workflow` scope). A Behat 4 leg would want its own
matrix entry, since the existing `symfony` key also raises `console` — which Behat 3 caps at `^7.0`.